### PR TITLE
Server  broadcast inputs

### DIFF
--- a/assets/scripts/application.coffee
+++ b/assets/scripts/application.coffee
@@ -17,13 +17,6 @@ requestAnimationFrame =
   (renderMethod) ->
     setTimeout(renderMethod, 10 / 6)
 
-cancelAnimationFrame =
-  window.cancelAnimationFrame or
-  window.webkitCancelAnimationFrame or
-  window.mozCancelAnimationFrame or
-  (handle) ->
-    clearTimeout(handle)
-
 module.exports = Component.create
   displayName: 'Application'
 

--- a/assets/scripts/application.coffee
+++ b/assets/scripts/application.coffee
@@ -10,12 +10,39 @@ GameProtocolMixin = require('./mixins/game_protocol_mixin')
 BlobPhysicsEngine = require('../../lib/local_modules/blob_physics_engine')
 Point = require('verlet-point')
 
-initialUuid = null
+requestAnimationFrame =
+  window.requestAnimationFrame or
+  window.webkitRequestAnimationFrame or
+  window.mozRequestAnimationFrame or
+  (renderMethod) ->
+    setTimeout(renderMethod, 10 / 6)
+
+cancelAnimationFrame =
+  window.cancelAnimationFrame or
+  window.webkitCancelAnimationFrame or
+  window.mozCancelAnimationFrame or
+  (handle) ->
+    clearTimeout(handle)
 
 module.exports = Component.create
   displayName: 'Application'
 
   mixins: [WsMixin, GameProtocolMixin]
+
+  getInitialState: ->
+    uuid: null
+    previous:
+      name: ''
+      mass: 10
+
+    worldAttrs:
+      min: [0, 0]
+      max: [1920, 1080]
+      gravity: [0, 0]
+
+    players: []
+
+  blobs: new Array()
 
   buildEngine: (options = { gravity: [0, 0], min: [0, 0], max: [1920, 1080], friction: 0.5, bounce: 1.0}) ->
     @engine = new BlobPhysicsEngine(options)
@@ -24,12 +51,12 @@ module.exports = Component.create
     switch message.channel
       when "server:info"
         @setState worldAttrs: message.data, =>
-          @lastUpdate = Date.now()
+          @blobs = new Array()
           @buildEngine(message.data)
-          @stepSimulation(@engine.blobs)
+          @setState lastUpdate: Date.now(), =>
+            @stepSimulation()
 
       when "client:info"
-        console.info 'info', message.data
         @setState uuid: message.data.uuid
 
       when "client:kick"
@@ -37,63 +64,50 @@ module.exports = Component.create
           @disconnectSocket()
 
       when "client:list"
-        console.info 'list', message.data
         @setState players: message.data
 
       when "game:step"
         return unless @engine?
         if message.data instanceof Array
-          @engine.blobs = _.map message.data, (blob) ->
+          @blobs = _.map message.data, (blob) ->
             pnt = Point(blob)
             pnt.ownerId = blob.ownerId
             pnt
 
-  stepSimulation: (blobs) ->
+      when "game:inputs"
+        inputs = message.data
+        @blobs = @retargetBlobsFromInput(@blobs, message.data)
+
+  retargetBlobsFromInput: (blobs, input) ->
+    _.map blobs, (blob) =>
+      return blob unless blob.ownerId == input.uuid
+
+      force = @engine.forceBlobTowards(blob, input.target)
+      blob.addForce force
+
+      blob
+
+
+  stepSimulation: (now) ->
     return unless @engine?
 
-    { lastUpdate } = @state
-    now = Date.now()
+    if @state.lastUpdate > 0
+      delta = (now - @state.lastUpdate) / 1000.0
 
-    if lastUpdate > 0
-      delta = (now - lastUpdate) / 1000.0
-      @lastUpdate = now
-
-      @engine.blobs = blobs
-      @engine.integrate(delta)
+      @engine.integrate(@blobs, delta)
 
     # Step simulation
+    requestAnimationFrame ((timestamp)=> @stepSimulation(timestamp))
     @setState lastUpdate: now
 
   setTarget: (point) ->
-    blobs = @engine.collectBlobsWith ownerId: @state.uuid
-    _.each blobs, (blob) ->
-      distance = Math.sqrt(
-        ((blob.position[0] - point[0]) * (blob.position[0] - point[0])) +
-        ((blob.position[1] - point[1]) * (blob.position[1] - point[1]))
-      )
-      if distance > 10
-        diff = _.map point, (axis, idx) ->
-          (axis - blob.position[idx]) / distance
-        blob.addForce diff
-    @sendTarget point
-
-  getInitialState: ->
-    uuid: initialUuid
-    previous:
-      name: ''
-      mass: 10
-
-    lastUpdate: null
-
-    worldAttrs:
-      min: [0, 0]
-      max: [1920, 1080]
-      gravity: [0, 0]
-
-    players: _.map [initialUuid], (id, rank) ->
-      uuid: id
-      name: sillyname()
-      rank: rank + 1
+    return unless @state.uuid
+    me = _.find @state.players, uuid: @state.uuid
+    if point
+      if point[0] != me.target[0] && point[1] != me.target[1]
+        @sendTarget point
+    else
+      @sendTarget null
 
   componentWillMount: ->
     @engine = null
@@ -102,9 +116,6 @@ module.exports = Component.create
   componentWillUnmount: ->
     @leaveGame()
     @engine = null
-
-  componentDidUpdate: ->
-    setTimeout (=> @stepSimulation(@engine.blobs)), 1
 
   render: ->
     React.DOM.div {},
@@ -116,6 +127,6 @@ module.exports = Component.create
         uuid: @state.uuid
         worldAttrs: @state.worldAttrs
         players: @state.players
-        blobs: if @engine? then @engine.blobs else []
+        blobs: @blobs
         setTarget: @setTarget
 

--- a/assets/scripts/components/join_modal/index.coffee
+++ b/assets/scripts/components/join_modal/index.coffee
@@ -57,7 +57,7 @@ module.exports = Component.create
         h2 {}, 'Start Mass'
         input
           type: 'number'
-          min: 0
+          min: 10
           max: 100
           defaultValue: previous.mass
           ref: 'mass'

--- a/assets/scripts/components/world/index.coffee
+++ b/assets/scripts/components/world/index.coffee
@@ -47,14 +47,11 @@ module.exports = Component.create
     local.x = parseInt(local.x)
     local.y = parseInt(local.y)
     @svgTarget = [local.x, local.y]
+    @updateTarget()
 
   handleMouseLeave: (e) ->
-    { uuid } = @props
-    return unless uuid
-
-    blob = _.find @props.blobs, ownerId: uuid
-
-    @svgTarget = blob.position
+    @svgTarget = null
+    @props.setTarget(null)
 
   render: ->
     { uuid, worldAttrs, players, blobs } = @props

--- a/assets/scripts/mixins/ws_mixin.coffee
+++ b/assets/scripts/mixins/ws_mixin.coffee
@@ -46,7 +46,7 @@ module.exports =
 
   sendMessage: (channel, data) ->
     raw = @createMessage(channel, data)
-    # console.log '<<< ', raw
+    console.log '<<< ', raw
     message = lz4.compress raw,
       outputEncoding: 'Base64'
 

--- a/assets/scripts/mixins/ws_mixin.coffee
+++ b/assets/scripts/mixins/ws_mixin.coffee
@@ -46,7 +46,6 @@ module.exports =
 
   sendMessage: (channel, data) ->
     raw = @createMessage(channel, data)
-    console.log '<<< ', raw
     message = lz4.compress raw,
       outputEncoding: 'Base64'
 

--- a/server/index.coffee
+++ b/server/index.coffee
@@ -41,7 +41,6 @@ if development()
       chunkModules: false
       modules: false
     },
-    lazy: true
   )
   console.log ' -> Webpack Hot Middleware'
   app.use WebpackHotMiddleware(compiler)

--- a/spec/lib/local_modules/blob_physics/addBlob.coffee
+++ b/spec/lib/local_modules/blob_physics/addBlob.coffee
@@ -5,16 +5,19 @@ describe 'blob_physics_engine', ->
   context 'addBlob', ->
     it 'succeeds when specifying an ownerId, x, y, and radius', ->
       engine = new BlobPhysicsEngine()
-      engine.addBlob('foo', [0, 0], 1)
-      expect(engine.blobs).to.have.length(1)
+      blobs = new Array()
+      engine.addBlob(blobs, 'foo', [0, 0], 1)
+      expect(blobs).to.have.length(1)
 
     it 'returns the newly created blob', ->
       engine = new BlobPhysicsEngine()
-      newBlob = engine.addBlob('foo', [0, 0], 1)
-      expect(engine.blobs[0]).to.equal(newBlob)
+      blobs = new Array()
+      newBlob = engine.addBlob(blobs, 'foo', [0, 0], 1)
+      expect(blobs[0]).to.equal(newBlob)
 
     it 'allows a null owner', ->
       engine = new BlobPhysicsEngine()
-      engine.addBlob(null, [0, 0], 1)
-      expect(engine.blobs).to.have.length(1)
+      blobs = new Array()
+      engine.addBlob(blobs, null, [0, 0], 1)
+      expect(blobs).to.have.length(1)
 

--- a/spec/lib/local_modules/blob_physics/calculateCollisionPoint.coffee
+++ b/spec/lib/local_modules/blob_physics/calculateCollisionPoint.coffee
@@ -7,8 +7,9 @@ describe 'blob_physics_engine', ->
   context 'distanceBetweenBlobs', ->
     it 'accurately calculates point of collision of two blobs', ->
       engine = new BlobPhysicsEngine()
-      a = engine.addBlob('foo', [0, 0], 10)
-      b = engine.addBlob('foo', [19, 0], 10)
+      blobs = new Array()
+      a = engine.addBlob(blobs, 'foo', [0, 0], 10)
+      b = engine.addBlob(blobs, 'foo', [19, 0], 10)
       collisionPoint = engine.calculateCollisionPoint(a, b)
       expect(collisionPoint.position[0]).to.equal(9.5)
       expect(collisionPoint.position[1]).to.equal(0)

--- a/spec/lib/local_modules/blob_physics/checkCollision.coffee
+++ b/spec/lib/local_modules/blob_physics/checkCollision.coffee
@@ -5,19 +5,22 @@ describe 'blob_physics_engine', ->
   context 'checkCollision', ->
     it 'returns true if two blobs are just touching', ->
       engine = new BlobPhysicsEngine()
-      a = engine.addBlob('foo', [0, 0], 10)
-      b = engine.addBlob('foo', [19, 0], 10)
+      blobs = new Array()
+      a = engine.addBlob(blobs, 'foo', [0, 0], 10)
+      b = engine.addBlob(blobs, 'foo', [19, 0], 10)
       expect(engine.checkCollision(a, b)).to.be.ok()
 
     it 'returns true if two blobs are just overlapping', ->
       engine = new BlobPhysicsEngine()
-      a = engine.addBlob('foo', [0, 0], 10)
-      b = engine.addBlob('foo', [10, 0], 10)
+      blobs = new Array()
+      a = engine.addBlob(blobs, 'foo', [0, 0], 10)
+      b = engine.addBlob(blobs, 'foo', [10, 0], 10)
       expect(engine.checkCollision(a, b)).to.be.ok()
 
     it 'returns false if two blobs are not touching', ->
       engine = new BlobPhysicsEngine()
-      a = engine.addBlob('foo', [0, 0], 10)
-      b = engine.addBlob('foo', [20, 0], 10)
+      blobs = new Array()
+      a = engine.addBlob(blobs, 'foo', [0, 0], 10)
+      b = engine.addBlob(blobs, 'foo', [20, 0], 10)
       expect(engine.checkCollision(a, b)).to.not.be.ok()
 

--- a/spec/lib/local_modules/blob_physics/collectBlobsWith.coffee
+++ b/spec/lib/local_modules/blob_physics/collectBlobsWith.coffee
@@ -6,30 +6,34 @@ describe 'blob_physics_engine', ->
   context 'collectBlobsWith', ->
     it 'returns an empty array when there are no blobs', ->
       engine = new BlobPhysicsEngine()
-      blobs = engine.collectBlobsWith(ownerId: 'foo')
-      expect(blobs).to.have.length(0)
+      blobs = new Array()
+      collected = engine.collectBlobsWith(blobs, ownerId: 'foo')
+      expect(collected).to.have.length(0)
 
     it 'returns a list of blobs owned by "foo"', ->
       engine = new BlobPhysicsEngine()
+      blobs = new Array()
       [0...10].forEach (blobNumber) ->
-        engine.addBlob('foo', 0, 0, 10)
+        engine.addBlob(blobs, 'foo', 0, 0, 10)
 
-      blobs = engine.collectBlobsWith(ownerId: 'foo')
-      expect(blobs).to.have.length(10)
+      collected = engine.collectBlobsWith(blobs, ownerId: 'foo')
+      expect(collected).to.have.length(10)
 
 
     it 'filters out blobs now owned by "foo"', ->
       engine = new BlobPhysicsEngine()
+      blobs = new Array()
       ['foo', 'foo', 'foo', 'bar', 'foo', 'bar', 'baz'].forEach (blobOwner) ->
-        engine.addBlob(blobOwner, 0, 0, 10)
+        engine.addBlob(blobs, blobOwner, 0, 0, 10)
 
-      blobs = engine.collectBlobsWith(ownerId: 'foo')
-      expect(blobs).to.have.length(4)
+      collected = engine.collectBlobsWith(blobs, ownerId: 'foo')
+      expect(collected).to.have.length(4)
 
     it 'does not filter when an empty set of attributes is passed', ->
       engine = new BlobPhysicsEngine()
+      blobs = new Array()
 
-      blobs = engine.collectBlobsWith(undefined)
-      expect(blobs).to.have.length(0)
+      collected = engine.collectBlobsWith(blobs, undefined)
+      expect(collected).to.have.length(0)
 
 

--- a/spec/lib/local_modules/blob_physics/distanceBetweenBlobs.coffee
+++ b/spec/lib/local_modules/blob_physics/distanceBetweenBlobs.coffee
@@ -6,6 +6,7 @@ describe 'blob_physics_engine', ->
   context 'distanceBetweenBlobs', ->
     it 'accurately calculates the distance between two blobs', ->
       engine = new BlobPhysicsEngine()
-      a = engine.addBlob('foo', [0, 0], 10)
-      b = engine.addBlob('foo', [999, 0], 10)
+      blobs = new Array()
+      a = engine.addBlob(blobs, 'foo', [0, 0], 10)
+      b = engine.addBlob(blobs, 'foo', [999, 0], 10)
       expect(engine.distanceBetweenBlobs(a, b)).to.equal(999)

--- a/spec/lib/local_modules/blob_physics/removeBlobsWith.coffee
+++ b/spec/lib/local_modules/blob_physics/removeBlobsWith.coffee
@@ -6,41 +6,37 @@ describe 'blob_physics_engine', ->
   context 'removeBlobsWith', ->
     it 'returns 0 when no blobs are removed', ->
       engine = new BlobPhysicsEngine()
-      numberRemoved = engine.removeBlobsWith(ownerId: 'foo')
-      expect(numberRemoved).to.equal(0)
+      blobs = new Array()
+      blobs = engine.removeBlobsWith(blobs, ownerId: 'foo')
+      expect(blobs.length).to.equal(0)
 
-    it 'removes all blobs owned by "foo"', ->
+    it 'removes all blobs owned by "foo" when all are owned by foo', ->
       engine = new BlobPhysicsEngine()
+      blobs = new Array()
       [0...10].forEach (blobNumber) ->
-        engine.addBlob('foo', 0, 0, 10)
+        engine.addBlob(blobs, 'foo', 0, 0, 10)
 
-      engine.removeBlobsWith(ownerId: 'foo')
-      expect(engine.blobs).to.have.length(0)
+      blobs = engine.removeBlobsWith(blobs, ownerId: 'foo')
+      expect(blobs).to.have.length(0)
 
 
-    it 'removes only blobs owned by "foo"', ->
+    it 'removes only blobs owned by "foo" when some are owned by foo', ->
       engine = new BlobPhysicsEngine()
-      ['foo', 'foo', 'foo', 'bar', 'foo', 'bar', 'baz'].forEach (blobOwner) ->
-        engine.addBlob(blobOwner, 0, 0, 10)
-
-      engine.removeBlobsWith(ownerId: 'foo')
-      expect(engine.blobs).to.have.length(3)
-
-    it '0 when an empty set of attributes is passed', ->
-      engine = new BlobPhysicsEngine()
+      blobs = new Array()
 
       ['foo', 'foo', 'foo', 'bar', 'foo', 'bar', 'baz'].forEach (blobOwner) ->
-        engine.addBlob(blobOwner, 0, 0, 10)
+        engine.addBlob(blobs, blobOwner, 0, 0, 10)
 
-      numberRemoved = engine.removeBlobsWith(undefined)
-      expect(numberRemoved).to.equal(0)
+      blobs = engine.removeBlobsWith(blobs, ownerId: 'foo')
+      expect(blobs).to.have.length(3)
 
     it 'does not mutate .blobs when no attributes are passed', ->
       engine = new BlobPhysicsEngine()
+      blobs = new Array()
 
       ['foo', 'foo', 'foo', 'bar', 'foo', 'bar', 'baz'].forEach (blobOwner) ->
-        engine.addBlob(blobOwner, 0, 0, 10)
+        engine.addBlob(blobs, blobOwner, 0, 0, 10)
 
-      engine.removeBlobsWith(undefined)
-      expect(engine.blobs).to.have.length(7)
+      blobs = engine.removeBlobsWith(blobs, undefined)
+      expect(blobs).to.have.length(7)
 


### PR DESCRIPTION
Many things have been changed for better client/server interpolarity
- Client uses requestAnimationFrame
- Both Client and Server use a decoupled-blob version of the physics engine, which allows me to add better external blob mutation methods to the client or server side.
- Moved blob targetting onto engine, since it belongs to both server and client
- Client properly runs simulation
- Server syncs simulation every client connection.  In the future, this may also be broadcast on a timer.
